### PR TITLE
Text in bMarkArea color black

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -156,3 +156,7 @@ body {
 .text {
   font-family: "Poppins", sans-serif;
 }
+
+.bMarkArea {
+  color: black;
+}


### PR DESCRIPTION
before, the white text update meant that all text is white, even in a white text area. this should fix that. 
![image](https://user-images.githubusercontent.com/81823039/128518139-fa8a88cb-fa8d-4dd1-b973-bd19eee1be9c.png)
